### PR TITLE
Use 0 instead of null as default timeout for addFunction

### DIFF
--- a/GearmanPeclManager.php
+++ b/GearmanPeclManager.php
@@ -48,7 +48,7 @@ class GearmanPeclManager extends GearmanManager {
         }
 
         foreach($worker_list as $w){
-            $timeout = (isset($timeouts[$w]) ? $timeouts[$w] : null);
+            $timeout = (isset($timeouts[$w]) ? $timeouts[$w] : 0);
             $this->log("Adding job $w ; timeout: " . $timeout, GearmanManager::LOG_LEVEL_WORKER_INFO);
             $thisWorker->addFunction($w, array($this, "do_job"), $this, $timeout);
         }


### PR DESCRIPTION
Fixes for PHP 7.4 with Gearman 2.1.0 extension